### PR TITLE
[FLOW-806] Remove flatten plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.11.0 (upcoming)
 
-* Pending changelog
+* [FLOW-806] Remove Flatten plugin in gitcommit profile
 
 ## 0.10.0 (May 09, 2018)
 

--- a/pom.xml
+++ b/pom.xml
@@ -423,30 +423,6 @@
                             </gitDescribe>
                         </configuration>
                     </plugin>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>flatten-maven-plugin</artifactId>
-                        <version>1.0.0</version>
-                        <configuration>
-                            <updatePomFile>true</updatePomFile>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>flatten</id>
-                                <phase>process-resources</phase>
-                                <goals>
-                                    <goal>flatten</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>flatten.clean</id>
-                                <phase>clean</phase>
-                                <goals>
-                                    <goal>clean</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
                 </plugins>
             </build>
         </profile>


### PR DESCRIPTION
If the version is going to be changed statically, the flatten plugin is not needed anymore