### PR TITLE
[FLOW-914] Add scoverage plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.12.0 (upcoming)
 
-* Pending changelog
+* [FLOW-914] Add scoverage plugin
 
 ## 0.11.0 (May 24, 2018)
 

--- a/pom.xml
+++ b/pom.xml
@@ -285,6 +285,11 @@
                         </execution>
                     </executions>
                 </plugin>
+                <plugin>
+                    <groupId>org.scoverage</groupId>
+                    <artifactId>scoverage-maven-plugin</artifactId>
+                    <version>1.3.0</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
Add version specification for the scoverage plugin. This will just set a common version for the plugin, but it will not add it to the children. It's their responsibility to add it and define needed variables when they want to have it
This is purely optional but probably advisable
